### PR TITLE
Refactored Media Ranker

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -37,8 +37,7 @@ class AlbumsController < ApplicationController
   end
 
   def upvote
-    @album.rank += 1
-    @album.save
+    Album.upvote(@album)
     redirect_to album_path(@album.id)
   end
 

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -10,7 +10,6 @@ class AlbumsController < ApplicationController
 
   def create
     @album = Album.new(create_params[:album])
-    @album.rank = 0
 
     if @album.save
       render :show

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,4 +1,5 @@
 class AlbumsController < ApplicationController
+  before_action :find_book, except: [:index, :new, :create]
 
   def index
    @albums = Album.ordered
@@ -9,7 +10,7 @@ class AlbumsController < ApplicationController
   end
 
   def create
-    @album = Album.new(create_params[:album])
+    @album = Album.new(album_params[:album])
 
     if @album.save
       render :show
@@ -18,17 +19,11 @@ class AlbumsController < ApplicationController
     end
   end
 
-  def edit
-    @album = Album.find(params[:id])
-  end
+  def edit; end
 
-  def show
-    @album = Album.find(params[:id])
-  end
+  def show; end
 
   def update
-    @album = Album.find(params[:id])
-
     name_input = params[:album][:name]
     artist_input = params[:album][:artist]
     description_input = params[:album][:description]
@@ -42,24 +37,23 @@ class AlbumsController < ApplicationController
   end
 
   def upvote
-    @album = Album.find(params[:id])
     @album.rank += 1
     @album.save
     redirect_to album_path(@album.id)
   end
 
   def destroy
-    Album.destroy(params[:id])
+    @album.destroy
     redirect_to '/albums'
   end
 
-private
+  private
 
-  def edit_params
-    params.permit(album: [:name, :artist, :description])
+  def find_album
+    @album = Album.find(params[:id])
   end
 
-  def create_params
+  def album_params
     params.permit(album: [:name, :artist, :description])
   end
 

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,5 +1,5 @@
 class AlbumsController < ApplicationController
-  before_action :find_book, except: [:index, :new, :create]
+  before_action :find_album, except: [:index, :new, :create]
 
   def index
    @albums = Album.ordered
@@ -24,11 +24,7 @@ class AlbumsController < ApplicationController
   def show; end
 
   def update
-    name_input = params[:album][:name]
-    artist_input = params[:album][:artist]
-    description_input = params[:album][:description]
-
-    @album.update(name: name_input, artist: artist_input, description: description_input)
+    @album.update(album_params[:album])
     if @album.save
       redirect_to album_path(@album.id)
     else

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,7 +10,6 @@ class BooksController < ApplicationController
 
   def create
     @book = Book.new(create_params[:book])
-    @book.rank = 0
 
     if @book.save
       render :show

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,4 +1,5 @@
 class BooksController < ApplicationController
+  before_action :find_book, except: [:index, :new, :create]
 
   def index
    @books = Book.ordered
@@ -9,7 +10,7 @@ class BooksController < ApplicationController
   end
 
   def create
-    @book = Book.new(create_params[:book])
+    @book = Book.new(book_params[:book])
 
     if @book.save
       render :show
@@ -19,17 +20,11 @@ class BooksController < ApplicationController
 
   end
 
-  def edit
-    @book = Book.find(params[:id])
-  end
+  def edit; end
 
-  def show
-    @book = Book.find(params[:id])
-  end
+  def show; end
 
   def update
-    @book = Book.find(params[:id])
-
     name_input = params[:book][:name]
     author_input = params[:book][:author]
     description_input = params[:book][:description]
@@ -43,24 +38,23 @@ class BooksController < ApplicationController
   end
 
   def upvote
-    @book = Book.find(params[:id])
     @book.rank += 1
     @book.save
     redirect_to book_path(@book.id)
   end
 
   def destroy
-    Book.destroy(params[:id])
+    @book.destroy
     redirect_to '/books'
   end
 
-private
+  private
 
-  def edit_params
-    params.permit(book: [:name, :author, :description])
+  def find_book
+    @book = Book.find(params[:id])
   end
 
-  def create_params
+  def book_params
     params.permit(book: [:name, :author, :description])
   end
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -38,8 +38,7 @@ class BooksController < ApplicationController
   end
 
   def upvote
-    @book.rank += 1
-    @book.save
+    Book.upvote(@book)
     redirect_to book_path(@book.id)
   end
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -25,11 +25,7 @@ class BooksController < ApplicationController
   def show; end
 
   def update
-    name_input = params[:book][:name]
-    author_input = params[:book][:author]
-    description_input = params[:book][:description]
-
-    @book.update(name: name_input, author: author_input , description: description_input)
+    @book.update(book_params[:book])
     if @book.save
       redirect_to book_path(@book.id)
     else

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,8 +1,8 @@
 class MoviesController < ApplicationController
+  before_action :find_movie, except: [:index, :new, :create]
 
   def index
    @movies = Movie.ordered
-   # I called a scope called 'ordered' to have all the movies listed in order
   end
 
   def new
@@ -19,16 +19,11 @@ class MoviesController < ApplicationController
     end
   end
 
-  def edit
-    @movie = Movie.find(params[:id])
-  end
+  def edit; end
 
-  def show
-    @movie = Movie.find(params[:id])
-  end
+  def show; end
 
   def update
-    @movie = Movie.find(params[:id])
     @movie.update(movie_params[:movie])
     if @movie.save
       redirect_to movie_path(@movie.id)
@@ -38,18 +33,21 @@ class MoviesController < ApplicationController
   end
 
   def upvote
-    @movie = Movie.find(params[:id])
     @movie.rank += 1
     @movie.save
     redirect_to movie_path(@movie.id)
   end
 
   def destroy
-    Movie.destroy(params[:id])
+    @move.destroy
     redirect_to movies_path
   end
 
   private
+
+  def find_movie
+    @movie = Movie.find(params[:id])
+  end
 
   def movie_params
     params.permit(movie: [:name, :director, :description])

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -11,7 +11,6 @@ class MoviesController < ApplicationController
 
   def create
     @movie = Movie.new(movie_params[:movie])
-    @movie.rank = 0
 
     if @movie.save
       render :show

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -33,8 +33,7 @@ class MoviesController < ApplicationController
   end
 
   def upvote
-    @movie.rank += 1
-    @movie.save
+    Movie.upvote(@movie)
     redirect_to movie_path(@movie.id)
   end
 

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -5,10 +5,9 @@ class Album < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
 
    # Scopes ---------------------------------------------------------------------
-
-  scope :top, -> { order('rank DESC').limit(5) }
+  scope :top, -> { ordered.limit(5) }
   scope :ordered, -> { order('rank DESC') }
-  
+
   def self.upvote(album)
     album.rank += 1
     album.save

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -2,7 +2,7 @@ class Album < ActiveRecord::Base
   # Associations ---------------------------------------------------------------
 
    # Validations ----------------------------------------------------------------
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
    # Scopes ---------------------------------------------------------------------
 

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -8,9 +8,7 @@ class Album < ActiveRecord::Base
 
   scope :top, -> { order('rank DESC').limit(5) }
   scope :ordered, -> { order('rank DESC') }
-  #  scope :on, -> (label) { where(label: label) }
-  #  scope :available_formats, -> { select(:format).distinct.order(:format).pluck(:format) }
-
+  
   def self.upvote(album)
     album.rank += 1
     album.save

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -11,5 +11,8 @@ class Album < ActiveRecord::Base
   #  scope :on, -> (label) { where(label: label) }
   #  scope :available_formats, -> { select(:format).distinct.order(:format).pluck(:format) }
 
-
+  def self.upvote(album)
+    album.rank += 1
+    album.save
+  end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -11,5 +11,9 @@ class Book < ActiveRecord::Base
   #  scope :on, -> (label) { where(label: label) }
   #  scope :available_formats, -> { select(:format).distinct.order(:format).pluck(:format) }
 
+  def self.upvote(book)
+    book.rank += 1
+    book.save
+  end
 
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -8,8 +8,6 @@ class Book < ActiveRecord::Base
 
   scope :top, -> { order('rank DESC').limit(5) }
   scope :ordered, -> { order('rank DESC') }
-  #  scope :on, -> (label) { where(label: label) }
-  #  scope :available_formats, -> { select(:format).distinct.order(:format).pluck(:format) }
 
   def self.upvote(book)
     book.rank += 1

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,9 +4,8 @@ class Book < ActiveRecord::Base
    # Validations ----------------------------------------------------------------
   validates :name, presence: true, uniqueness: true
 
-   # Scopes ---------------------------------------------------------------------
-
-  scope :top, -> { order('rank DESC').limit(5) }
+   # Scopes --------------------------------------------------------------------
+  scope :top, -> { ordered.limit(5) }
   scope :ordered, -> { order('rank DESC') }
 
   def self.upvote(book)

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,7 +2,7 @@ class Book < ActiveRecord::Base
   # Associations ---------------------------------------------------------------
 
    # Validations ----------------------------------------------------------------
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
    # Scopes ---------------------------------------------------------------------
 

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -8,9 +8,6 @@ class Movie < ActiveRecord::Base
   scope :top, -> { order('rank DESC').limit(5) }
   scope :ordered, -> { order('rank DESC') }
 
-    # scope :desc, order("event_at DESC")
-  #  scope :available_formats, -> { select(:format).distinct.order(:format).pluck(:format) }
-
   def self.upvote(movie)
     movie.rank += 1
     movie.save

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -2,7 +2,7 @@ class Movie < ActiveRecord::Base
   # Associations ---------------------------------------------------------------
 
    # Validations ----------------------------------------------------------------
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
    # Scopes ---------------------------------------------------------------------
   scope :top, -> { order('rank DESC').limit(5) }

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -11,4 +11,8 @@ class Movie < ActiveRecord::Base
     # scope :desc, order("event_at DESC")
   #  scope :available_formats, -> { select(:format).distinct.order(:format).pluck(:format) }
 
+  def self.upvote(movie)
+    movie.rank += 1
+    movie.save
+  end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -5,7 +5,7 @@ class Movie < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
 
    # Scopes ---------------------------------------------------------------------
-  scope :top, -> { order('rank DESC').limit(5) }
+  scope :top, -> { ordered.limit(5) }
   scope :ordered, -> { order('rank DESC') }
 
   def self.upvote(movie)

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -1,15 +1,13 @@
 <div class="row">
-<div class="col-lg-12">
-<h1><%= @album.name %><small> Recorded by: <%= @album.artist %> </small></h1>
-<h4> Ranked: <%= @album.rank %> </h4>
-<p> <%= @album.description %> </p>
+  <div class="col-lg-12">
+    <h1><%= @album.name %><small> Recorded by: <%= @album.artist %> </small></h1>
+    <h4> Ranked: <%= @album.rank %> </h4>
+    <p> <%= @album.description %> </p>
 
-<p style="margin:0;padding:0;display:inline"> <%= button_to "Upvote", upvote_album_path(@album.id), method: :patch, :class => "btn btn-primary"%> </p>
-
-
-<%= link_to "Edit #{@album.name}", edit_album_path(@album.id), method: :get, :class => "btn btn-default" %>
-<%= link_to "DELETE", album_path, method: :delete, :class => "btn btn-danger", data: { confirm: "Are you sure?" } %>
-<%= link_to "View All Albums", albums_path, method: :get, :class => "btn btn-default" %>
-<%= link_to "View All Media", root_path, method: :get, :class => "btn btn-default" %>
-</div>
+    <p style="margin:0;padding:0;display:inline"> <%= button_to "Upvote", upvote_album_path(@album.id), method: :patch, :class => "btn btn-primary"%> </p>
+    <%= link_to "Edit #{@album.name}", edit_album_path(@album.id), method: :get, :class => "btn btn-default" %>
+    <%= link_to "DELETE", album_path, method: :delete, :class => "btn btn-danger", data: { confirm: "Are you sure?" } %>
+    <%= link_to "View All Albums", albums_path, method: :get, :class => "btn btn-default" %>
+    <%= link_to "View All Media", root_path, method: :get, :class => "btn btn-default" %>
+  </div>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,15 +1,13 @@
 <div class="row">
-<div class="col-lg-12">
-<h1><%= @book.name %><small> Written by: <%= @book.author %> </small></h1>
-<h4> Ranked: <%= @book.rank %> </h4>
-<p> <%= @book.description %> </p>
+  <div class="col-lg-12">
+  <h1><%= @book.name %><small> Written by: <%= @book.author %> </small></h1>
+  <h4> Ranked: <%= @book.rank %> </h4>
+  <p> <%= @book.description %> </p>
 
-<p style="margin:0;padding:0;display:inline"> <%= button_to "Upvote", upvote_book_path(@book.id), method: :patch, :class => "btn btn-primary" %> </p>
-
-
-<%= link_to "Edit #{@book.name}", edit_book_path(@book.id), :method => "get", :class => "btn btn-default" %>
-<%= link_to "Delete", book_path, method: :delete, :class => "btn btn-danger", data: { confirm: "Are you sure?" } %>
-<%= link_to "View All Books", books_path , method: :get, :class => "btn btn-default"%>
-<%= link_to "View All Media", root_path, method: :get, :class => "btn btn-default" %>
-</div>
+  <p style="margin:0;padding:0;display:inline"> <%= button_to "Upvote", upvote_book_path(@book.id), method: :patch, :class => "btn btn-primary" %> </p>
+  <%= link_to "Edit #{@book.name}", edit_book_path(@book.id), :method => "get", :class => "btn btn-default" %>
+  <%= link_to "Delete", book_path, method: :delete, :class => "btn btn-danger", data: { confirm: "Are you sure?" } %>
+  <%= link_to "View All Books", books_path , method: :get, :class => "btn btn-default"%>
+  <%= link_to "View All Media", root_path, method: :get, :class => "btn btn-default" %>
+  </div>
 </div>

--- a/app/views/movies/show.html.erb
+++ b/app/views/movies/show.html.erb
@@ -1,15 +1,13 @@
 <div class="row">
-<div class="col-lg-12">
-<h1><%= @movie.name %><small> Directed by: <%= @movie.director %> </small></h1>
-<h4>Ranked: <%= @movie.rank %></h4>
-<p><%= @movie.description %></p>
+  <div class="col-lg-12">
+    <h1><%= @movie.name %><small> Directed by: <%= @movie.director %> </small></h1>
+    <h4>Ranked: <%= @movie.rank %></h4>
+    <p><%= @movie.description %></p>
 
-<p style="margin:0;padding:0;display:inline"> <%= button_to "Upvote", upvote_movie_path(@movie.id), method: :patch, :class => "btn btn-primary" %> </p>
-
-
-<%= link_to "Edit #{@movie.name}", edit_movie_path(@movie.id), method: :get, :class => "btn btn-default" %>
-<%= link_to "Delete", movie_path, method: :delete, :class => "btn btn-danger", data: { confirm: "Are you sure?" }%>
-<%= link_to "View All Movies", movies_path , method: :get, :class => "btn btn-default" %>
-<%= link_to "View All Media", root_path, method: :get, :class => "btn btn-default" %>
-</div>
+    <p style="margin:0;padding:0;display:inline"> <%= button_to "Upvote", upvote_movie_path(@movie.id), method: :patch, :class => "btn btn-primary" %> </p>
+    <%= link_to "Edit #{@movie.name}", edit_movie_path(@movie.id), method: :get, :class => "btn btn-default" %>
+    <%= link_to "Delete", movie_path, method: :delete, :class => "btn btn-danger", data: { confirm: "Are you sure?" }%>
+    <%= link_to "View All Movies", movies_path , method: :get, :class => "btn btn-default" %>
+    <%= link_to "View All Media", root_path, method: :get, :class => "btn btn-default" %>
+  </div>
 </div>

--- a/db/migrate/20150802221014_add_default_value_for_rank.rb
+++ b/db/migrate/20150802221014_add_default_value_for_rank.rb
@@ -1,0 +1,8 @@
+class AddDefaultValueForRank < ActiveRecord::Migration
+  def change
+    change_column :albums, :rank, :integer, :default => 0
+    change_column :movies, :rank, :integer, :default => 0
+    change_column :books, :rank, :integer, :default => 0
+  end
+  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,33 +11,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150706223847) do
+ActiveRecord::Schema.define(version: 20150802221014) do
 
   create_table "albums", force: :cascade do |t|
     t.string   "name"
     t.string   "artist"
     t.string   "description"
-    t.integer  "rank"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "rank",        default: 0
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   create_table "books", force: :cascade do |t|
     t.string   "name"
     t.string   "author"
     t.string   "description"
-    t.integer  "rank"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "rank",        default: 0
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   create_table "movies", force: :cascade do |t|
     t.string   "name"
     t.string   "director"
     t.string   "description"
-    t.integer  "rank"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "rank",        default: 0
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
 end


### PR DESCRIPTION
Refactoring Media Ranker

Some of the things that I changed were:
- Getting rid of assignment operator in the controllers. I made a migration to the schema so all of the model’s default ranking is 0 instead of having to declare model_name.rank = 0 in the controller’s upvote method. 
- Eliminating arithmetic operators in the controllers. I moved the upvote method of all three controllers to their respective models.
- I added before_action to DRY up the methods that required you to find the instance of each medium. `Ex: @movie = Movie.find(params[:id])`
- Really minor, but I used the ordered scope in the top scope. Scope on Scope action. Didn't save any lines but it seems cooler to look at so I went with it.
- There was a bunch of unnecessary logic for the params in the update methods. Since I now have a much better understanding of how params works, I was able to edit it and DRY it up.

We learned so much since completing Media Ranker, so it's cool to see how I can apply these new concepts to DRY up the code.
